### PR TITLE
Update Linux library name

### DIFF
--- a/TDLib/Bindings/LinuxBindings.cs
+++ b/TDLib/Bindings/LinuxBindings.cs
@@ -5,7 +5,7 @@ namespace TD.Bindings
 {
     internal static class LinuxBindings
     {
-        private const string Dll = "libtdjson.so";
+        private const string Dll = "tdjson";
         
         [DllImport(Dll)]
         internal static extern IntPtr td_json_client_create();


### PR DESCRIPTION
With that change, I was able to start and register with egram.tel using tdsharp on Ubuntu 18.04.